### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/action-check.yml
+++ b/.github/workflows/action-check.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v4.2.2
         with:
           token: ${{ secrets.GH_TOKEN }}
       - name: Run GitHub Actions Version Updater

--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -26,13 +26,13 @@ jobs:
         os: [windows-latest,ubuntu-latest,macos-latest,macos-13]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v4.2.2
       - name: Use Node.js 20.x
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@v4.1.0
         with:
           node-version: "20"
       - name: Cache NPM dependencies
-        uses: actions/cache@v4.0.2
+        uses: actions/cache@v4.2.0
         with:
           path: ./electron-static/node_modules
           key: ${{ runner.os }}-npm-app-cache
@@ -51,7 +51,7 @@ jobs:
          cd electron-static
          7z a -tzip genish-impact-${{ runner.os }}-${{runner.arch}}.zip ./genish-impact-*
       - name: Upload (${{ runner.os }})
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4.4.3
         with:
           name: genish-impact-${{ runner.os }}-${{runner.arch}}
           path: electron-static/genish-impact-${{ runner.os }}-${{runner.arch}}.zip

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -12,16 +12,16 @@ jobs:
   Build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v4.2.2
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v3.7.1
       - name: Login to DockerHub
-        uses: docker/login-action@v3.1.0
+        uses: docker/login-action@v3.3.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build & Push to DockerHub
-        uses: docker/build-push-action@v5.3.0
+        uses: docker/build-push-action@v6.10.0
         with:
           context: .
           push: true

--- a/.github/workflows/page.yml
+++ b/.github/workflows/page.yml
@@ -18,13 +18,13 @@ jobs:
   Build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v4.2.2
       - name: Use Node.js 20.x
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@v4.1.0
         with:
           node-version: "20"
       - name: Cache NPM dependencies
-        uses: actions/cache@v4.0.2
+        uses: actions/cache@v4.2.0
         with:
           path: ./Genshin-Impact-Wish-Simulator/node_modules
           key: ${{ runner.OS }}-npm-frontend-cache
@@ -43,7 +43,7 @@ jobs:
          cd Genshin-Impact-Wish-Simulator
          7z a -tzip frontend.zip ./.vercel/output/static
       - name: Upload
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4.4.3
         with:
           name: frontend
           path: Genshin-Impact-Wish-Simulator/frontend.zip
@@ -58,9 +58,9 @@ jobs:
          git config --global user.name github-actions[bot]
          git config --global user.email 41898282+github-actions[bot]@users.noreply.github.com
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4.2.2
       - name: Download Artifact
-        uses: actions/download-artifact@v4.1.4
+        uses: actions/download-artifact@v4.1.8
         with:
             name: frontend
       - name: Remove old

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,11 +17,11 @@ jobs:
     needs: app
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v4.2.2
       - name: Download Artifact
-        uses: actions/download-artifact@v4.1.4
+        uses: actions/download-artifact@v4.1.8
       - name: Create Release
-        uses: softprops/action-gh-release@v2.0.4
+        uses: softprops/action-gh-release@v2.1.0
         with:
             files: ./**/genish-impact*.*
             body_path: ./CHANGELOG.md

--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -13,7 +13,7 @@ jobs:
             os: [windows-latest,ubuntu-latest,macos-latest,macos-13]
         runs-on: ${{ matrix.os }}
         steps:
-          - uses: actions/checkout@v4.1.1
+          - uses: actions/checkout@v4.2.2
           - name: install Rust stable
             uses: dtolnay/rust-toolchain@stable
           - name: install dependencies (ubuntu only)
@@ -22,18 +22,18 @@ jobs:
               sudo apt-get update
               sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev libappindicator3-dev librsvg2-dev patchelf
           - name: Use Node.js 20.x
-            uses: actions/setup-node@v4.0.2
+            uses: actions/setup-node@v4.1.0
             with:
               node-version: "20"
           - name: Cache NPM dependencies
-            uses: actions/cache@v4.0.2
+            uses: actions/cache@v4.2.0
             with:
               path: ./Genshin-Impact-Wish-Simulator/node_modules
               key: ${{ runner.OS }}-${{runner.arch}}-npm-frontend-cache
               restore-keys: |
                 ${{ runner.OS }}-npm-frontend-cache
           - name: Cache Rust
-            uses: Swatinem/rust-cache@v2.7.3
+            uses: Swatinem/rust-cache@v2.7.5
             with:
               prefix-key: "Cache-${{ runner.os }}-${{runner.arch}}"
               workspaces: "Genshin-Impact-Wish-Simulator/src-tauri"
@@ -48,25 +48,25 @@ jobs:
              yarn run tauri build
           - name: Upload (Windows)
             if: runner.os == 'windows'
-            uses: actions/upload-artifact@v4.3.1
+            uses: actions/upload-artifact@v4.4.3
             with:
               name: genish-impact-Tauri-${{ runner.os }}
               path: Genshin-Impact-Wish-Simulator/src-tauri/target/release/bundle/
           - name: Upload Appimage (Linux)
             if: runner.os == 'Linux'
-            uses: actions/upload-artifact@v4.3.1
+            uses: actions/upload-artifact@v4.4.3
             with:
               name: genish-impact-Tauri-${{ runner.os }}-appimage
               path: Genshin-Impact-Wish-Simulator/src-tauri/target/release/bundle/appimage/genish-impact_*.AppImage
           - name: Upload deb (Linux)
             if: runner.os == 'Linux'
-            uses: actions/upload-artifact@v4.3.1
+            uses: actions/upload-artifact@v4.4.3
             with:
               name: genish-impact-Tauri-${{ runner.os }}-deb
               path: Genshin-Impact-Wish-Simulator/src-tauri/target/release/bundle/deb/genish-impact_*.deb
           - name: Upload dmg (Macos)
             if: runner.os == 'macos'
-            uses: actions/upload-artifact@v4.3.1
+            uses: actions/upload-artifact@v4.4.3
             with:
               name: genish-impact-Tauri-${{ runner.os }}-dmg-${{runner.arch}}
               path: Genshin-Impact-Wish-Simulator/src-tauri/target/release/bundle/dmg/*.dmg

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -20,13 +20,13 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v4.2.2
       - name: Use Node.js 20.x
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@v4.1.0
         with:
           node-version: "20"
       - name: Cache NPM dependencies
-        uses: actions/cache@v4.0.2
+        uses: actions/cache@v4.2.0
         with:
           path: ./webdocs/node_modules
           key: ${{ runner.OS }}-npm-frontend-cache
@@ -41,7 +41,7 @@ jobs:
          cd webdocs
          yarn run build
       - name: Deploy
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v3.0.1
         with:
           path: ./webdocs/docs/.vitepress/dist
   deploy:
@@ -56,4 +56,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v4.0.5


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/deploy-pages](https://github.com/actions/deploy-pages)** published a new release **[v4.0.5](https://github.com/actions/deploy-pages/releases/tag/v4.0.5)** on 2024-03-18T15:43:13Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.2.2](https://github.com/actions/checkout/releases/tag/v4.2.2)** on 2024-10-23T14:46:00Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v4.4.3](https://github.com/actions/upload-artifact/releases/tag/v4.4.3)** on 2024-10-09T17:17:34Z
* **[actions/download-artifact](https://github.com/actions/download-artifact)** published a new release **[v4.1.8](https://github.com/actions/download-artifact/releases/tag/v4.1.8)** on 2024-07-05T15:12:41Z
* **[docker/login-action](https://github.com/docker/login-action)** published a new release **[v3.3.0](https://github.com/docker/login-action/releases/tag/v3.3.0)** on 2024-07-22T09:07:15Z
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v6.10.0](https://github.com/docker/build-push-action/releases/tag/v6.10.0)** on 2024-11-26T10:49:47Z
* **[Swatinem/rust-cache](https://github.com/Swatinem/rust-cache)** published a new release **[v2.7.5](https://github.com/Swatinem/rust-cache/releases/tag/v2.7.5)** on 2024-10-12T10:16:57Z
* **[softprops/action-gh-release](https://github.com/softprops/action-gh-release)** published a new release **[v2.1.0](https://github.com/softprops/action-gh-release/releases/tag/v2.1.0)** on 2024-11-11T20:16:36Z
* **[actions/upload-pages-artifact](https://github.com/actions/upload-pages-artifact)** published a new release **[v3.0.1](https://github.com/actions/upload-pages-artifact/releases/tag/v3.0.1)** on 2024-02-07T06:59:16Z
* **[docker/setup-buildx-action](https://github.com/docker/setup-buildx-action)** published a new release **[v3.7.1](https://github.com/docker/setup-buildx-action/releases/tag/v3.7.1)** on 2024-10-04T07:44:26Z
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v4.1.0](https://github.com/actions/setup-node/releases/tag/v4.1.0)** on 2024-10-24T13:51:16Z
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v4.2.0](https://github.com/actions/cache/releases/tag/v4.2.0)** on 2024-12-05T16:45:49Z
