### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -51,7 +51,7 @@ jobs:
          cd electron-static
          7z a -tzip genish-impact-${{ runner.os }}-${{runner.arch}}.zip ./genish-impact-*
       - name: Upload (${{ runner.os }})
-        uses: actions/upload-artifact@v4.4.3
+        uses: actions/upload-artifact@v4.5.0
         with:
           name: genish-impact-${{ runner.os }}-${{runner.arch}}
           path: electron-static/genish-impact-${{ runner.os }}-${{runner.arch}}.zip

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -15,14 +15,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3.7.1
+        uses: docker/setup-buildx-action@v3.8.0
       - name: Login
         uses: docker/login-action@v3.3.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build & Push
-        uses: docker/build-push-action@v6.10.0
+        uses: docker/build-push-action@v6.11.0
         with:
           context: .
           push: true
@@ -36,7 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3.7.1
+        uses: docker/setup-buildx-action@v3.8.0
       - name: Login
         uses: docker/login-action@v3.3.0
         with:
@@ -44,7 +44,7 @@ jobs:
           username: ${{ secrets.GH_USERNAME }}
           password: ${{ secrets.GH_TOKEN }}
       - name: Build & Push
-        uses: docker/build-push-action@v6.10.0
+        uses: docker/build-push-action@v6.11.0
         with:
           context: .
           push: true

--- a/.github/workflows/page.yml
+++ b/.github/workflows/page.yml
@@ -43,7 +43,7 @@ jobs:
          cd Genshin-Impact-Wish-Simulator
          7z a -tzip frontend.zip ./.vercel/output/static
       - name: Upload
-        uses: actions/upload-artifact@v4.4.3
+        uses: actions/upload-artifact@v4.5.0
         with:
           name: frontend
           path: Genshin-Impact-Wish-Simulator/frontend.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Download Artifact
         uses: actions/download-artifact@v4.1.8
       - name: Create Release
-        uses: softprops/action-gh-release@v2.1.0
+        uses: softprops/action-gh-release@v2.2.1
         with:
             files: ./**/genish-impact*.*
             body_path: ./CHANGELOG.md

--- a/.github/workflows/tauri.yml
+++ b/.github/workflows/tauri.yml
@@ -33,7 +33,7 @@ jobs:
               restore-keys: |
                 ${{ runner.OS }}-npm-frontend-cache
           - name: Cache Rust
-            uses: Swatinem/rust-cache@v2.7.5
+            uses: Swatinem/rust-cache@v2.7.7
             with:
               prefix-key: "Cache-${{ runner.os }}-${{runner.arch}}"
               workspaces: "Genshin-Impact-Wish-Simulator/src-tauri"
@@ -48,25 +48,25 @@ jobs:
              yarn run tauri build
           - name: Upload (Windows)
             if: runner.os == 'windows'
-            uses: actions/upload-artifact@v4.4.3
+            uses: actions/upload-artifact@v4.5.0
             with:
               name: genish-impact-Tauri-${{ runner.os }}
               path: Genshin-Impact-Wish-Simulator/src-tauri/target/release/bundle/
           - name: Upload Appimage (Linux)
             if: runner.os == 'Linux'
-            uses: actions/upload-artifact@v4.4.3
+            uses: actions/upload-artifact@v4.5.0
             with:
               name: genish-impact-Tauri-${{ runner.os }}-appimage
               path: Genshin-Impact-Wish-Simulator/src-tauri/target/release/bundle/appimage/genish-impact_*.AppImage
           - name: Upload deb (Linux)
             if: runner.os == 'Linux'
-            uses: actions/upload-artifact@v4.4.3
+            uses: actions/upload-artifact@v4.5.0
             with:
               name: genish-impact-Tauri-${{ runner.os }}-deb
               path: Genshin-Impact-Wish-Simulator/src-tauri/target/release/bundle/deb/genish-impact_*.deb
           - name: Upload dmg (Macos)
             if: runner.os == 'macos'
-            uses: actions/upload-artifact@v4.4.3
+            uses: actions/upload-artifact@v4.5.0
             with:
               name: genish-impact-Tauri-${{ runner.os }}-dmg-${{runner.arch}}
               path: Genshin-Impact-Wish-Simulator/src-tauri/target/release/bundle/dmg/*.dmg


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v4.5.0](https://github.com/actions/upload-artifact/releases/tag/v4.5.0)** on 2024-12-17T22:02:43Z
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v6.11.0](https://github.com/docker/build-push-action/releases/tag/v6.11.0)** on 2025-01-08T09:17:44Z
* **[Swatinem/rust-cache](https://github.com/Swatinem/rust-cache)** published a new release **[v2.7.7](https://github.com/Swatinem/rust-cache/releases/tag/v2.7.7)** on 2024-12-29T07:49:27Z
* **[docker/setup-buildx-action](https://github.com/docker/setup-buildx-action)** published a new release **[v3.8.0](https://github.com/docker/setup-buildx-action/releases/tag/v3.8.0)** on 2024-12-16T09:47:41Z
* **[softprops/action-gh-release](https://github.com/softprops/action-gh-release)** published a new release **[v2.2.1](https://github.com/softprops/action-gh-release/releases/tag/v2.2.1)** on 2025-01-07T18:45:50Z
